### PR TITLE
create a local HEADER_REGEX for each _readHeader call

### DIFF
--- a/lib/hdr-load.js
+++ b/lib/hdr-load.js
@@ -9,7 +9,6 @@ module.exports = HDRLoader;
 
 var MINLEN = 8;
 var MAXLEN = 0x7fff;
-var HEADER_REGEX = /([\#\?]+)?([^=\n\r]+)?=?([^=\n\r]*)?([\n\r]+)/gi;
 var DIMENSION_REGEX = /^([+\-])([XY])\s(\d+)\s([+\-])([XY])\s(\d+)/i;
 var HEADER_PREFIXES = {
 	'#?': 'FILETYPE',
@@ -267,6 +266,8 @@ HDRLoader.prototype._readHeader = function (chunk) {
 	var str = chunk.toString('ascii'),
 	    sliceOffset = 0,
 	    headerData;
+
+	var HEADER_REGEX = /([\#\?]+)?([^=\n\r]+)?=?([^=\n\r]*)?([\n\r]+)/gi;
 
 	while (headerData = HEADER_REGEX.exec(str)) {
 		sliceOffset += headerData[0].length;


### PR DESCRIPTION
Hi,

When loading several hdr files, subsequent parsing may (always?) fail.
The static `HEADER_REGEX` keep it's `RegExp.lastIndex` value from last `_readHeader` calls, and cause unexpected behaviours.

Here i replaced the static `HEADER_REGEX`by a local one. 

Pierre
